### PR TITLE
Change React.PureComponent to React.Component

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  https://github.com/Monar/react-immutable-pure-component
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                */
 
-var ImmutablePureComponent = exports.ImmutablePureComponent = function (_React$PureComponent) {
-  _inherits(ImmutablePureComponent, _React$PureComponent);
+var ImmutablePureComponent = exports.ImmutablePureComponent = function (_React$Component) {
+  _inherits(ImmutablePureComponent, _React$Component);
 
   function ImmutablePureComponent() {
     _classCallCheck(this, ImmutablePureComponent);
@@ -50,6 +50,6 @@ var ImmutablePureComponent = exports.ImmutablePureComponent = function (_React$P
   }]);
 
   return ImmutablePureComponent;
-}(_react2.default.PureComponent);
+}(_react2.default.Component);
 
 exports.default = ImmutablePureComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { is } from 'immutable';
 
 
-export class ImmutablePureComponent extends React.PureComponent {
+export class ImmutablePureComponent extends React.Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     const state = this.state || {};


### PR DESCRIPTION
Overwriting `shouldComponentUpdate` with `React.PureComponent` is not allowed in React 16.

In `ImmutablePureComponent`, since the method of `React.PureComponent` is not used, it is replaced with `React.Component`.

![](https://cloud.githubusercontent.com/assets/12539/26571141/5070218c-454f-11e7-8d88-27b9779fa28a.png)