### PR TITLE
Move dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,14 @@
     "babel-cli": "^6.23.0",
     "babel-preset-es2015": "6.22.0",
     "babel-preset-react": "6.22.0",
-    "babel-preset-stage-3": "6.22.0"
-  },
-  "dependencies": {
+    "babel-preset-stage-3": "6.22.0",
     "immutable": "^3.8.1",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
+  },
+  "peerDependencies": {
+    "immutable": "^3.8.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   }
 }


### PR DESCRIPTION
Move `react` and `react-dom` to `peerDependencies` to prevent them from being installed duplicately.
