### PR TITLE
Add support Universal Module Definition (UMD) using rollup.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": [ "react", "es2015", "stage-3" ],
+  "presets": [
+    "react",
+    ["es2015", { modules: false }],
+    "stage-3"
+  ]
 }

--- a/example/example.js
+++ b/example/example.js
@@ -8,7 +8,6 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var _Immutable = Immutable,
     List = _Immutable.List;
-var ImmutablePureComponent = ImmutablePureComponent.ImmutablePureComponent;
 
 var Example = function (_React$Component) {
   _inherits(Example, _React$Component);

--- a/example/example.js
+++ b/example/example.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -9,61 +7,34 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _Immutable = Immutable,
-    is = _Immutable.is,
     List = _Immutable.List;
+var ImmutablePureComponent = ImmutablePureComponent.ImmutablePureComponent;
 
-var ImmutablePureComponent = function (_React$Component) {
-  _inherits(ImmutablePureComponent, _React$Component);
-
-  function ImmutablePureComponent() {
-    _classCallCheck(this, ImmutablePureComponent);
-
-    return _possibleConstructorReturn(this, (ImmutablePureComponent.__proto__ || Object.getPrototypeOf(ImmutablePureComponent)).apply(this, arguments));
-  }
-
-  _createClass(ImmutablePureComponent, [{
-    key: 'shouldComponentUpdate',
-    value: function shouldComponentUpdate(nextProps, nextState) {
-      var _this2 = this;
-
-      var state = this.state || {};
-
-      return !(this.updateOnProps || Object.keys(nextProps)).every(function (p) {
-        return is(nextProps[p], _this2.props[p]);
-      }) || !(this.updateOnStates || Object.keys(nextState || {})).every(function (s) {
-        return is(nextState[s], state[s]);
-      });
-    }
-  }]);
-
-  return ImmutablePureComponent;
-}(React.Component);
-
-var Example = function (_React$Component2) {
-  _inherits(Example, _React$Component2);
+var Example = function (_React$Component) {
+  _inherits(Example, _React$Component);
 
   function Example(props) {
     _classCallCheck(this, Example);
 
-    var _this3 = _possibleConstructorReturn(this, (Example.__proto__ || Object.getPrototypeOf(Example)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (Example.__proto__ || Object.getPrototypeOf(Example)).call(this, props));
 
-    _this3.state = {
+    _this.state = {
       items: List(),
       current: 'square'
     };
 
-    _this3.handleAdd = function () {
-      var _this3$state = _this3.state,
-          items = _this3$state.items,
-          current = _this3$state.current;
+    _this.handleAdd = function () {
+      var _this$state = _this.state,
+          items = _this$state.items,
+          current = _this$state.current;
 
-      _this3.setState({
+      _this.setState({
         items: items.push(current),
         current: current === 'circle' ? 'square' : 'circle'
       });
     };
 
-    return _this3;
+    return _this;
   }
 
   _createClass(Example, [{

--- a/example/index.js
+++ b/example/index.js
@@ -1,5 +1,4 @@
 const { List } = Immutable;
-const { ImmutablePureComponent } = ImmutablePureComponent;
 
 class Example extends React.Component {
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,14 +1,5 @@
-const { is, List } = Immutable;
-
-class ImmutablePureComponent extends React.Component {
-
-  shouldComponentUpdate(nextProps, nextState) {
-    const state = this.state || {};
-
-    return !(this.updateOnProps || Object.keys(nextProps)).every((p) => is(nextProps[p], this.props[p]))
-      || !(this.updateOnStates || Object.keys(nextState || {})).every((s) => is(nextState[s], state[s]));
-  }
-}
+const { List } = Immutable;
+const { ImmutablePureComponent } = ImmutablePureComponent;
 
 class Example extends React.Component {
 
@@ -100,4 +91,3 @@ class ItemList2 extends ImmutablePureComponent {
 }
 
 ReactDOM.render(<Example/>, document.getElementById('example'));
-

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react-dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.8.1/immutable.min.js"></script>
+  <script src="lib/index.js"></script>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,31 +1,26 @@
-'use strict';
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('react'), require('immutable')) :
+	typeof define === 'function' && define.amd ? define(['exports', 'react', 'immutable'], factory) :
+	(factory((global.ImmutablePureComponent = global.ImmutablePureComponent || {}),global.React,global.Immutable));
+}(this, (function (exports,React,immutable) { 'use strict';
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.ImmutablePureComponent = undefined;
+React = 'default' in React ? React['default'] : React;
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-var _react = require('react');
-
-var _react2 = _interopRequireDefault(_react);
-
-var _immutable = require('immutable');
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /*
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 Copyright (C) 2017 Piotr Tomasz Monarski.
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 Licensed under the MIT License (MIT), see
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 https://github.com/Monar/react-immutable-pure-component
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               */
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var ImmutablePureComponent = exports.ImmutablePureComponent = function (_React$Component) {
+/*
+  Copyright (C) 2017 Piotr Tomasz Monarski.
+  Licensed under the MIT License (MIT), see
+  https://github.com/Monar/react-immutable-pure-component
+*/
+
+var ImmutablePureComponent = function (_React$Component) {
   _inherits(ImmutablePureComponent, _React$Component);
 
   function ImmutablePureComponent() {
@@ -42,14 +37,19 @@ var ImmutablePureComponent = exports.ImmutablePureComponent = function (_React$C
       var state = this.state || {};
 
       return !(this.updateOnProps || Object.keys(nextProps)).every(function (p) {
-        return (0, _immutable.is)(nextProps[p], _this2.props[p]);
+        return immutable.is(nextProps[p], _this2.props[p]);
       }) || !(this.updateOnStates || Object.keys(nextState || {})).every(function (s) {
-        return (0, _immutable.is)(nextState[s], state[s]);
+        return immutable.is(nextState[s], state[s]);
       });
     }
   }]);
 
   return ImmutablePureComponent;
-}(_react2.default.Component);
+}(React.Component);
 
-exports.default = ImmutablePureComponent;
+exports.ImmutablePureComponent = ImmutablePureComponent;
+exports['default'] = ImmutablePureComponent;
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('react'), require('immutable')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'react', 'immutable'], factory) :
-	(factory((global.ImmutablePureComponent = global.ImmutablePureComponent || {}),global.React,global.Immutable));
+	(factory((global.window = global.window || {}),global.React,global.Immutable));
 }(this, (function (exports,React,immutable) { 'use strict';
 
 React = 'default' in React ? React['default'] : React;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React PureComponent implementation embracing Immutable.js",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel src --out-dir lib",
+    "build": "rollup -c",
     "example": "babel example/index.js --out-file example/example.js",
     "lint": "eslint ."
   },
@@ -28,7 +28,10 @@
     "babel-preset-stage-3": "6.22.0",
     "immutable": "^3.8.1",
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "rollup": "^0.42.0",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-node-resolve": "^3.0.0"
   },
   "peerDependencies": {
     "immutable": "^3.8.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ export default {
   entry: 'src/index.js',
   format: 'umd',
   exports: 'named',
-  moduleName: 'ImmutablePureComponent',
+  moduleName: 'window',
   plugins: [
     resolve({
       customResolveOptions: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,25 @@
+import babel from 'rollup-plugin-babel';
+import resolve from 'rollup-plugin-node-resolve';
+
+export default {
+  entry: 'src/index.js',
+  format: 'umd',
+  exports: 'named',
+  moduleName: 'ImmutablePureComponent',
+  plugins: [
+    resolve({
+      customResolveOptions: {
+        moduleDirectory: 'node_modules',
+      },
+    }),
+    babel({
+      exclude: 'node_modules/**',
+    }),
+  ],
+  globals: {
+    react: 'React',
+    immutable: 'Immutable',
+  },
+  external: ['react', 'immutable'],
+  dest: 'lib/index.js',
+};


### PR DESCRIPTION
[Universal Module Definition (UMD)](https://github.com/umdjs/umd) is useful for making Node.js compatible with Web Browsers.

### use case

#### JavaScript (for Node.js)

```javascript
import React from 'react';
import ReactDOM from 'react-dom';
import ImmutablePureComponent from 'react-immutable-pure-component';

class Component extends ImmutablePureComponent {
  render() {
    return React.createElement('div', null, 'value');
  }
}

ReactDOM.render(React.createElement(Component), document.getElementById('root'));
```

### HTML (for Web Browsers)

```html
<script src="https://unpkg.com/react@15.5.4/dist/react.min.js"></script>
<script src="https://unpkg.com/react-dom@15.5.4/dist/react-dom.min.js"></script>
<script src="https://unpkg.com/react-immutable-pure-component"></script>
<script>
(() => {
  const { ImmutablePureComponent } = ImmutablePureComponent;

  class Component extends ImmutablePureComponent {
    render() {
      return React.createElement('div', null, 'value');
    }
  }

  ReactDOM.render(React.createElement(Component), document.getElementById('root'));
})();
</script>
